### PR TITLE
Return mongoose find with no text search argument when no search query is passed in

### DIFF
--- a/index.js
+++ b/index.js
@@ -369,6 +369,10 @@ module.exports = function (schema, options) {
         }
 
         var queryString = isObject(args[0]) ? args[0].query : args[0];
+        
+        if (!queryString) {
+            return Model['find'].apply(this);
+        }
 
         var checkPrefixOnly = isObject(args[0]) ? args[0].prefixOnly : constants.DEFAULT_PREFIX_ONLY;
         var defaultNgamMinSize = isObject(args[0]) ? args[0].minSize : constants.DEFAULT_MIN_SIZE;

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -100,6 +100,15 @@ describe('new versions of js (with Object.values)', function () {
                 done();
             });
 
+            it("fuzzySearch() -> should find one user with empty string as first parameter", function (done) {
+                User2.fuzzySearch('').then(function (result) {
+                    expect(result).to.have.lengthOf(1);
+                    done();
+                }).catch(function (err) {
+                    done(err)
+                });
+            });
+
             it("fuzzySearch() -> should find one user with string as first parameter", function (done) {
                 User2.fuzzySearch('jo').then(function (result) {
                     expect(result).to.have.lengthOf(1);

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -118,8 +118,26 @@ describe('new versions of js (with Object.values)', function () {
                 });
             });
 
+            it("fuzzySearch() -> should find one user with object with empty query as first parameter", function (done) {
+                User2.fuzzySearch({ query: '' }).then(function (result) {
+                    expect(result).to.have.lengthOf(1);
+                    done();
+                }).catch(function (err) {
+                    done(err);
+                });
+            });
+
             it("fuzzySearch() -> should find one user with object as first parameter", function (done) {
                 User2.fuzzySearch({ query: 'jo' }).then(function (result) {
+                    expect(result).to.have.lengthOf(1);
+                    done();
+                }).catch(function (err) {
+                    done(err);
+                });
+            });
+
+            it("fuzzySearch() -> should find one user with object with empty query as first parameter (with `prefixOnly`)", function (done) {
+                User2.fuzzySearch({ query: '', prefixOnly: true }).then(function (result) {
                     expect(result).to.have.lengthOf(1);
                     done();
                 }).catch(function (err) {


### PR DESCRIPTION
I'm using this to allow for a search query param, but when there's no search term there are no matches. Let me know what you think! This is one of my first OSS contributions. :)

Fixes https://github.com/VassilisPallas/mongoose-fuzzy-searching/issues/43