### PR TITLE
fix(ISS-68): Generate fromObject method

### DIFF
--- a/helpers/db/fields.js
+++ b/helpers/db/fields.js
@@ -50,9 +50,8 @@ class Generate {
   }
 
   fromString(item) {
-    if (this.attributes[item]) {
-      let value = this.attributes[item];
-
+    let value = this.attributes[item];
+    if (value) {
       if (Array.isArray(value)) {
         value = value.join(' ');
       }
@@ -62,10 +61,16 @@ class Generate {
   }
 
   fromObject(item) {
-    if (this.attributes[`${item.name}`]) {
+    let value = this.attributes[`${item.name}`];
+    if (value) {
       const escapeSpecialCharacters = item.escapeSpecialCharacters !== false;
+
+      if (Array.isArray(value)) {
+        value = value.join(' ');
+      }
+
       this.attributes[`${item.name}_fuzzy`] = this.makeNGrams(
-        this.attributes[item.name],
+        value,
         escapeSpecialCharacters,
         item.minSize,
         item.prefixOnly,

--- a/helpers/db/fields.spec.js
+++ b/helpers/db/fields.spec.js
@@ -136,17 +136,21 @@ describe('createNGrams', () => {
         key_test_1: '1234',
         key_test_2: '1234',
       },
+      some__array__name: ['some_name', 'some_name2'],
+      some__array__name2: ['some_name', 'some_name2'],
     };
     fields = [
       'test',
+      'some__array__name',
       { keys: ['key_test_1', 'key_test_2'], name: 'some__key_name' },
       { name: 'some_name', weight: 10 },
+      { name: 'some__array__name2' },
     ];
 
     createField = (obj) => (item, index) => {
-      if (index === 0) {
+      if (index <= 1) {
         obj.fromString(item);
-      } else if (index === 1) {
+      } else if (index === 2) {
         obj.fromObjectKeys(item);
       } else {
         obj.fromObject(item);
@@ -157,18 +161,14 @@ describe('createNGrams', () => {
     expect(attributes).toStrictEqual({
       test: 'test',
       some_name: 'some_name',
-      some__key_name: {
-        key_test_1: '1234',
-        key_test_2: '1234',
-      },
+      some__key_name: { key_test_1: '1234', key_test_2: '1234' },
+      some__array__name: ['some_name', 'some_name2'],
+      some__array__name2: ['some_name', 'some_name2'],
       test_fuzzy: 'test',
+      some__array__name_fuzzy: 'some_name some_name2',
+      some__key_name_fuzzy: [{ key_test_1_fuzzy: '1234', key_test_2_fuzzy: '1234' }],
       some_name_fuzzy: 'some_name',
-      some__key_name_fuzzy: [
-        {
-          key_test_1_fuzzy: '1234',
-          key_test_2_fuzzy: '1234',
-        },
-      ],
+      some__array__name2_fuzzy: 'some_name some_name2',
     });
   });
 


### PR DESCRIPTION
## Description
An error will be throw if a field is an array and configure it with an `object` format. 
```js
// tags if an array of string
schema.plugin(fuzzySearch, {
  fields: [{ name: 'tags' }]
});
```
and this PR will fix the issues