### PR TITLE
Pass filter args along even when there's no query

### DIFF
--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -61,6 +61,11 @@ describe('fuzzySearch', () => {
       const result = await Model.fuzzySearch('');
       expect(result).toHaveLength(1);
     });
+    
+    it('fuzzySearch() -> should find no users with empty string as first parameter and excluding all results as second parameter', async () => {
+      const result = await Model.fuzzySearch('', { _id: null });
+      expect(result).toHaveLength(0);
+    });
 
     it('fuzzySearch() -> should find one user with string as first parameter', async () => {
       const result = await Model.fuzzySearch('jo');

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function fuzzySearch(...args) {
 
   const { exact, queryString } = getArgs(queryArgs[0]);
   if (!queryString) {
-    return this.find();
+    return this.find(queryArgs[1]);
   }
 
   const { checkPrefixOnly, defaultNgamMinSize } = getDefaultValues(queryArgs[0]);


### PR DESCRIPTION
## Description

A previous contribution of mine ran `Model.find()` when no query existed, but my added tests did not cover this case and since then a regression was introduced where the `find()` runs, but any filters passed as a second arg to `fuzzySearch()` are discarded.

## How to test that change

`Model.fuzzySearch('', { _id: null })` should return an empty array b/c every document will have `_id`

No issue created

## Checklist

Tests

- [x] I've added integration tests
- [ ] I've added unit tests

Documentation

- [ ] I've updated readme

Review process

- [ ] The title is in present tense and includes the issue number
- [x] I've used [conventional commits](https://www.conventionalcommits.org/) (ish.. sorry!)
